### PR TITLE
Add IdentityCache entity

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ import { SignatureEntity } from './src/entities/signatureEntity'
 import { VerifiableCredentialEntity } from './src/entities/verifiableCredentialEntity'
 import { CacheEntity } from './src/entities/cacheEntity'
 import { InteractionTokenEntity } from './src/entities/interactionTokenEntity'
+import { IdentityCacheEntity } from './src/entities/identityCacheEntity'
 
 export {
   SettingEntity,
@@ -16,6 +17,7 @@ export {
   VerifiableCredentialEntity,
   CacheEntity,
   InteractionTokenEntity,
+  IdentityCacheEntity
 }
 
 export const entityList = [
@@ -27,6 +29,7 @@ export const entityList = [
   VerifiableCredentialEntity,
   CacheEntity,
   InteractionTokenEntity,
+  IdentityCacheEntity
 ]
 
 export { JolocomTypeormStorage } from './src'

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -6,6 +6,7 @@ import { SignatureEntity } from './src/entities/signatureEntity';
 import { VerifiableCredentialEntity } from './src/entities/verifiableCredentialEntity';
 import { CacheEntity } from './src/entities/cacheEntity';
 import { InteractionTokenEntity } from './src/entities/interactionTokenEntity';
-export { SettingEntity, CredentialEntity, EncryptedWalletEntity, EventLogEntity, SignatureEntity, VerifiableCredentialEntity, CacheEntity, InteractionTokenEntity, };
+import { IdentityCacheEntity } from './src/entities/identityCacheEntity';
+export { SettingEntity, CredentialEntity, EncryptedWalletEntity, EventLogEntity, SignatureEntity, VerifiableCredentialEntity, CacheEntity, InteractionTokenEntity, IdentityCacheEntity };
 export declare const entityList: (typeof SettingEntity | typeof EncryptedWalletEntity | typeof SignatureEntity | typeof VerifiableCredentialEntity | typeof CredentialEntity | typeof InteractionTokenEntity | typeof EventLogEntity)[];
 export { JolocomTypeormStorage } from './src';

--- a/js/index.js
+++ b/js/index.js
@@ -16,6 +16,8 @@ const cacheEntity_1 = require("./src/entities/cacheEntity");
 exports.CacheEntity = cacheEntity_1.CacheEntity;
 const interactionTokenEntity_1 = require("./src/entities/interactionTokenEntity");
 exports.InteractionTokenEntity = interactionTokenEntity_1.InteractionTokenEntity;
+const identityCacheEntity_1 = require("./src/entities/identityCacheEntity");
+exports.IdentityCacheEntity = identityCacheEntity_1.IdentityCacheEntity;
 exports.entityList = [
     settingEntity_1.SettingEntity,
     credentialEntity_1.CredentialEntity,
@@ -25,6 +27,7 @@ exports.entityList = [
     verifiableCredentialEntity_1.VerifiableCredentialEntity,
     cacheEntity_1.CacheEntity,
     interactionTokenEntity_1.InteractionTokenEntity,
+    identityCacheEntity_1.IdentityCacheEntity
 ];
 var src_1 = require("./src");
 exports.JolocomTypeormStorage = src_1.JolocomTypeormStorage;

--- a/js/src/entities/identityCacheEntity.d.ts
+++ b/js/src/entities/identityCacheEntity.d.ts
@@ -1,0 +1,4 @@
+export declare class IdentityCacheEntity {
+    key: string;
+    value: any;
+}

--- a/js/src/entities/identityCacheEntity.js
+++ b/js/src/entities/identityCacheEntity.js
@@ -1,0 +1,20 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const tslib_1 = require("tslib");
+const typeorm_1 = require("typeorm");
+const class_transformer_1 = require("class-transformer");
+let IdentityCacheEntity = class IdentityCacheEntity {
+};
+tslib_1.__decorate([
+    typeorm_1.PrimaryColumn(),
+    tslib_1.__metadata("design:type", String)
+], IdentityCacheEntity.prototype, "key", void 0);
+tslib_1.__decorate([
+    typeorm_1.Column({ nullable: false, type: 'simple-json' }),
+    tslib_1.__metadata("design:type", Object)
+], IdentityCacheEntity.prototype, "value", void 0);
+IdentityCacheEntity = tslib_1.__decorate([
+    typeorm_1.Entity('identityCache'),
+    class_transformer_1.Expose()
+], IdentityCacheEntity);
+exports.IdentityCacheEntity = IdentityCacheEntity;

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -3,9 +3,9 @@ import { Connection } from 'typeorm';
 import { SignedCredential } from 'jolocom-lib/js/credentials/signedCredential/signedCredential';
 import { CredentialOfferMetadata, CredentialOfferRenderInfo } from 'jolocom-lib/js/interactionTokens/interactionTokens.types';
 import { IdentitySummary } from '@jolocom/sdk/js/src/lib/types';
-import { DidDocument } from 'jolocom-lib/js/identity/didDocument/didDocument';
 import { InternalDb } from '@jolocom/local-resolver-registrar/js/db';
 import { JWTEncodable, JSONWebToken } from 'jolocom-lib/js/interactionTokens/JSONWebToken';
+import { Identity } from 'jolocom-lib/js/identity/identity';
 export interface PersonaAttributes {
     did: string;
     controllingKeyPath: string;
@@ -25,7 +25,7 @@ export declare class JolocomTypeormStorage implements IStorage {
         encryptedWallet: (args: EncryptedWalletAttributes) => Promise<void>;
         credentialMetadata: (credentialMetadata: CredentialMetadataSummary) => Promise<void>;
         issuerProfile: (issuer: IdentitySummary) => Promise<void>;
-        didDoc: (doc: DidDocument) => Promise<void>;
+        identity: (identity: Identity) => Promise<void>;
         interactionToken: (token: JSONWebToken<JWTEncodable>) => Promise<void>;
     };
     get: {
@@ -47,7 +47,7 @@ export declare class JolocomTypeormStorage implements IStorage {
         encryptedWallet: (id?: string | undefined) => Promise<EncryptedWalletAttributes | null>;
         credentialMetadata: ({ issuer, type: credentialType, }: SignedCredential) => Promise<any>;
         publicProfile: (did: string) => Promise<IdentitySummary>;
-        didDoc: (did: string) => Promise<DidDocument>;
+        identity: (did: string) => Promise<Identity>;
         interactionTokens: (attrs: {
             nonce?: string | undefined;
             type?: string | undefined;
@@ -70,11 +70,13 @@ export declare class JolocomTypeormStorage implements IStorage {
     private getMetadataForCredential;
     private getPublicProfile;
     private getCachedDIDDoc;
+    private getCachedIdentity;
     private storeEncryptedWallet;
     private storeEncryptedSeed;
     private storeCredentialMetadata;
     private storeIssuerProfile;
     private cacheDIDDoc;
+    private cacheIdentity;
     private storeInteractionToken;
     private storeVClaim;
     private deleteVCred;

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -47,7 +47,7 @@ export declare class JolocomTypeormStorage implements IStorage {
         encryptedWallet: (id?: string | undefined) => Promise<EncryptedWalletAttributes | null>;
         credentialMetadata: ({ issuer, type: credentialType, }: SignedCredential) => Promise<any>;
         publicProfile: (did: string) => Promise<IdentitySummary>;
-        identity: (did: string) => Promise<Identity>;
+        identity: (did: string) => Promise<Identity | undefined>;
         interactionTokens: (attrs: {
             nonce?: string | undefined;
             type?: string | undefined;

--- a/js/src/index.d.ts
+++ b/js/src/index.d.ts
@@ -1,11 +1,11 @@
-import { IStorage, EncryptedWalletAttributes, EncryptedSeedAttributes } from '@jolocom/sdk/js/src/lib/storage';
+import { IStorage, EncryptedWalletAttributes, EncryptedSeedAttributes } from '@jolocom/sdk/js/storage';
 import { Connection } from 'typeorm';
 import { SignedCredential } from 'jolocom-lib/js/credentials/signedCredential/signedCredential';
 import { CredentialOfferMetadata, CredentialOfferRenderInfo } from 'jolocom-lib/js/interactionTokens/interactionTokens.types';
-import { IdentitySummary } from '@jolocom/sdk/js/src/lib/types';
 import { InternalDb } from '@jolocom/local-resolver-registrar/js/db';
 import { JWTEncodable, JSONWebToken } from 'jolocom-lib/js/interactionTokens/JSONWebToken';
 import { Identity } from 'jolocom-lib/js/identity/identity';
+import { IdentitySummary } from '@jolocom/sdk/js/types';
 export interface PersonaAttributes {
     did: string;
     controllingKeyPath: string;
@@ -69,13 +69,11 @@ export declare class JolocomTypeormStorage implements IStorage {
     private findTokens;
     private getMetadataForCredential;
     private getPublicProfile;
-    private getCachedDIDDoc;
     private getCachedIdentity;
     private storeEncryptedWallet;
     private storeEncryptedSeed;
     private storeCredentialMetadata;
     private storeIssuerProfile;
-    private cacheDIDDoc;
     private cacheIdentity;
     private storeInteractionToken;
     private storeVClaim;

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -172,7 +172,7 @@ class JolocomTypeormStorage {
             const [entry] = yield this.connection.manager.findByIds(identityCacheEntity_1.IdentityCacheEntity, [
                 did
             ]);
-            return identity_1.Identity.fromJSON(entry.value);
+            return entry && entry.value && identity_1.Identity.fromJSON(entry.value);
         });
     }
     storeEncryptedWallet(args) {

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -14,6 +14,8 @@ const class_transformer_1 = require("class-transformer");
 const didDocument_1 = require("jolocom-lib/js/identity/didDocument/didDocument");
 const utils_1 = require("./utils");
 const jolocom_lib_1 = require("jolocom-lib");
+const identity_1 = require("jolocom-lib/js/identity/identity");
+const identityCacheEntity_1 = require("./entities/identityCacheEntity");
 /**
  * @todo IdentitySummary is a UI type, which can always be
  * derived from a DID Doc and Public Profile.
@@ -29,7 +31,7 @@ class JolocomTypeormStorage {
             encryptedWallet: this.storeEncryptedWallet.bind(this),
             credentialMetadata: this.storeCredentialMetadata.bind(this),
             issuerProfile: this.storeIssuerProfile.bind(this),
-            didDoc: this.cacheDIDDoc.bind(this),
+            identity: this.cacheIdentity.bind(this),
             interactionToken: this.storeInteractionToken.bind(this),
         };
         this.get = {
@@ -42,7 +44,7 @@ class JolocomTypeormStorage {
             encryptedWallet: this.getEncryptedWallet.bind(this),
             credentialMetadata: this.getMetadataForCredential.bind(this),
             publicProfile: this.getPublicProfile.bind(this),
-            didDoc: this.getCachedDIDDoc.bind(this),
+            identity: this.getCachedIdentity.bind(this),
             interactionTokens: this.findTokens.bind(this)
         };
         this.delete = {
@@ -174,6 +176,14 @@ class JolocomTypeormStorage {
             return didDocument_1.DidDocument.fromJSON(entry.value);
         });
     }
+    getCachedIdentity(did) {
+        return tslib_1.__awaiter(this, void 0, void 0, function* () {
+            const [entry] = yield this.connection.manager.findByIds(identityCacheEntity_1.IdentityCacheEntity, [
+                did
+            ]);
+            return identity_1.Identity.fromJSON(entry.value);
+        });
+    }
     storeEncryptedWallet(args) {
         return tslib_1.__awaiter(this, void 0, void 0, function* () {
             const encryptedWallet = class_transformer_1.plainToClass(encryptedWalletEntity_1.EncryptedWalletEntity, args);
@@ -210,6 +220,15 @@ class JolocomTypeormStorage {
             const cacheEntry = class_transformer_1.plainToClass(cacheEntity_1.CacheEntity, {
                 key: `didCache:${doc.did}`,
                 value: doc.toJSON(),
+            });
+            yield this.connection.manager.save(cacheEntry);
+        });
+    }
+    cacheIdentity(identity) {
+        return tslib_1.__awaiter(this, void 0, void 0, function* () {
+            const cacheEntry = class_transformer_1.plainToClass(identityCacheEntity_1.IdentityCacheEntity, {
+                key: identity.did,
+                value: identity.toJSON()
             });
             yield this.connection.manager.save(cacheEntry);
         });

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -11,7 +11,6 @@ const interactionTokenEntity_1 = require("./entities/interactionTokenEntity");
 const eventLogEntity_1 = require("./entities/eventLogEntity");
 const encryptedWalletEntity_1 = require("./entities/encryptedWalletEntity");
 const class_transformer_1 = require("class-transformer");
-const didDocument_1 = require("jolocom-lib/js/identity/didDocument/didDocument");
 const utils_1 = require("./utils");
 const jolocom_lib_1 = require("jolocom-lib");
 const identity_1 = require("jolocom-lib/js/identity/identity");
@@ -168,14 +167,6 @@ class JolocomTypeormStorage {
             return (issuerProfile && issuerProfile.value) || { did };
         });
     }
-    getCachedDIDDoc(did) {
-        return tslib_1.__awaiter(this, void 0, void 0, function* () {
-            const [entry] = yield this.connection.manager.findByIds(cacheEntity_1.CacheEntity, [
-                `didCache:${did}`,
-            ]);
-            return didDocument_1.DidDocument.fromJSON(entry.value);
-        });
-    }
     getCachedIdentity(did) {
         return tslib_1.__awaiter(this, void 0, void 0, function* () {
             const [entry] = yield this.connection.manager.findByIds(identityCacheEntity_1.IdentityCacheEntity, [
@@ -211,15 +202,6 @@ class JolocomTypeormStorage {
             const cacheEntry = class_transformer_1.plainToClass(cacheEntity_1.CacheEntity, {
                 key: issuer.did,
                 value: issuer,
-            });
-            yield this.connection.manager.save(cacheEntry);
-        });
-    }
-    cacheDIDDoc(doc) {
-        return tslib_1.__awaiter(this, void 0, void 0, function* () {
-            const cacheEntry = class_transformer_1.plainToClass(cacheEntity_1.CacheEntity, {
-                key: `didCache:${doc.did}`,
-                value: doc.toJSON(),
             });
             yield this.connection.manager.save(cacheEntry);
         });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@jolocom/sdk": "^1.0.0-rc10",
-    "jolocom-lib": "^5.1.0-rc9",
+    "jolocom-lib": "^5.1.0-rc12",
     "typeorm": "^0.2.24"
   },
   "dependencies": {
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@jolocom/sdk": "^1.0.0-rc10",
     "@types/ramda": "^0.27.14",
-    "jolocom-lib": "^5.1.0-rc9",
+    "jolocom-lib": "^5.1.0-rc12",
     "@jolocom/local-resolver-registrar": "^1.0.0-rc1",
     "typeorm": "^0.2.24",
     "typescript": "^3.8.3"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Jolocom Dev <dev@jolocom.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@jolocom/sdk": "^1.0.0-rc10",
+    "@jolocom/sdk": "^1.0.0-rc12",
     "jolocom-lib": "^5.1.0-rc12",
     "typeorm": "^0.2.24"
   },
@@ -24,7 +24,7 @@
     "ramda": "^0.27.1"
   },
   "devDependencies": {
-    "@jolocom/sdk": "^1.0.0-rc10",
+    "@jolocom/sdk": "^1.0.0-rc12",
     "@types/ramda": "^0.27.14",
     "jolocom-lib": "^5.1.0-rc12",
     "@jolocom/local-resolver-registrar": "^1.0.0-rc1",

--- a/src/entities/identityCacheEntity.ts
+++ b/src/entities/identityCacheEntity.ts
@@ -1,0 +1,12 @@
+import { Entity, Column, PrimaryColumn } from 'typeorm'
+import { Expose } from 'class-transformer'
+
+@Entity('identityCache')
+@Expose()
+export class IdentityCacheEntity {
+  @PrimaryColumn()
+  key!: string
+
+  @Column({ nullable: false, type: 'simple-json' })
+  value!: any
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,12 +199,12 @@ export class JolocomTypeormStorage implements IStorage {
     return (issuerProfile && issuerProfile.value) || { did }
   }
 
-  private async getCachedIdentity(did: string): Promise<Identity> {
+  private async getCachedIdentity(did: string): Promise<undefined | Identity> {
     const [entry] = await this.connection.manager.findByIds(IdentityCacheEntity, [
       did
     ])
 
-    return Identity.fromJSON(entry.value)
+    return entry && entry.value && Identity.fromJSON(entry.value)
   }
   
   private async storeEncryptedWallet(

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { InteractionTokenEntity } from './entities/interactionTokenEntity'
 import { EventLogEntity } from './entities/eventLogEntity'
 import { EncryptedWalletEntity } from './entities/encryptedWalletEntity'
 
-import { IStorage, EncryptedWalletAttributes, EncryptedSeedAttributes } from '@jolocom/sdk/js/src/lib/storage'
+import { IStorage, EncryptedWalletAttributes, EncryptedSeedAttributes } from '@jolocom/sdk/js/storage'
 import { Connection } from 'typeorm'
 import { plainToClass } from 'class-transformer'
 import { SignedCredential } from 'jolocom-lib/js/credentials/signedCredential/signedCredential'
@@ -16,8 +16,6 @@ import {
   CredentialOfferMetadata,
   CredentialOfferRenderInfo,
 } from 'jolocom-lib/js/interactionTokens/interactionTokens.types'
-import { IdentitySummary } from '@jolocom/sdk/js/src/lib/types'
-import { DidDocument } from 'jolocom-lib/js/identity/didDocument/didDocument'
 import { groupAttributesByCredentialId } from './utils'
 import { InternalDb } from '@jolocom/local-resolver-registrar/js/db'
 
@@ -28,6 +26,7 @@ import {
 import { JolocomLib } from 'jolocom-lib'
 import { Identity } from 'jolocom-lib/js/identity/identity'
 import { IdentityCacheEntity } from './entities/identityCacheEntity'
+import { IdentitySummary } from '@jolocom/sdk/js/types'
 
 export interface PersonaAttributes {
   did: string
@@ -200,14 +199,6 @@ export class JolocomTypeormStorage implements IStorage {
     return (issuerProfile && issuerProfile.value) || { did }
   }
 
-  private async getCachedDIDDoc(did: string): Promise<DidDocument> {
-    const [entry] = await this.connection.manager.findByIds(CacheEntity, [
-      `didCache:${did}`,
-    ])
-
-    return DidDocument.fromJSON(entry.value)
-  }
-
   private async getCachedIdentity(did: string): Promise<Identity> {
     const [entry] = await this.connection.manager.findByIds(IdentityCacheEntity, [
       did
@@ -247,15 +238,6 @@ export class JolocomTypeormStorage implements IStorage {
     const cacheEntry = plainToClass(CacheEntity, {
       key: issuer.did,
       value: issuer,
-    })
-
-    await this.connection.manager.save(cacheEntry)
-  }
-
-  private async cacheDIDDoc(doc: DidDocument) {
-    const cacheEntry = plainToClass(CacheEntity, {
-      key: `didCache:${doc.did}`,
-      value: doc.toJSON(),
     })
 
     await this.connection.manager.save(cacheEntry)

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,6 @@ export class JolocomTypeormStorage implements IStorage {
     encryptedWallet: this.storeEncryptedWallet.bind(this),
     credentialMetadata: this.storeCredentialMetadata.bind(this),
     issuerProfile: this.storeIssuerProfile.bind(this),
-    didDoc: this.cacheDIDDoc.bind(this),
     identity: this.cacheIdentity.bind(this),
     interactionToken: this.storeInteractionToken.bind(this),
   }
@@ -66,7 +65,6 @@ export class JolocomTypeormStorage implements IStorage {
     encryptedWallet: this.getEncryptedWallet.bind(this),
     credentialMetadata: this.getMetadataForCredential.bind(this),
     publicProfile: this.getPublicProfile.bind(this),
-    didDoc: this.getCachedDIDDoc.bind(this),
     identity: this.getCachedIdentity.bind(this),
     interactionTokens: this.findTokens.bind(this)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -421,6 +421,13 @@
   dependencies:
     cred-types-jolocom-core "^0.0.11"
 
+"@jolocom/protocol-ts@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@jolocom/protocol-ts/-/protocol-ts-0.5.2.tgz#291a6865f2c3eeb47443bf8be3210848baeb5d25"
+  integrity sha512-vQq5EhapRaxyzM3UaEAycoej1jdaU6RWM1yNeh47SqHqEfRsxsVrI3MYAuUeCXaq5ULv4MCwrDt/Y6ARsR4EOA==
+  dependencies:
+    cred-types-jolocom-core "^0.0.11"
+
 "@jolocom/registry-contract@^1.0.0-rc5":
   version "1.0.0-rc5"
   resolved "https://registry.yarnpkg.com/@jolocom/registry-contract/-/registry-contract-1.0.0-rc5.tgz#0596a708e4e86deddf19602799b35b58d51b7c3e"
@@ -428,11 +435,12 @@
   dependencies:
     ethers "5.0.5"
 
-"@jolocom/sdk@^1.0.0-rc10":
-  version "1.0.0-rc10"
-  resolved "https://registry.yarnpkg.com/@jolocom/sdk/-/sdk-1.0.0-rc10.tgz#32d58aaeb16f2efba31b19a11c13b39b5d916469"
-  integrity sha512-8NCHLtwy6+0uBODf5AJg9R/01TYChPDCHfEqcJVKh771NTrHoFcrH9RxLv25ZCF9A/bn8u2fKjNivkk5ayrQ3A==
+"@jolocom/sdk@^1.0.0-rc12":
+  version "1.0.0-rc12"
+  resolved "https://registry.yarnpkg.com/@jolocom/sdk/-/sdk-1.0.0-rc12.tgz#910df7431f37e76e8dd6439e4d6399a119620751"
+  integrity sha512-cpvXQlipwh6/TuadROeoi1s3b6JV9V0IxZ4xUZ3M91g23IekLkv1bGhMPoW0ESX0vLTNNAa4Q1K/OAOzZN2G0g==
   dependencies:
+    "@jolocom/protocol-ts" "^0.5.2"
     form-data "^3.0.0"
     ramda "^0.26.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@decentralized-identity/did-common-typescript@^0.1.19":
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/@decentralized-identity/did-common-typescript/-/did-common-typescript-0.1.19.tgz#91c6dd59311e849cbc91fcff81b65c1a966163b6"
+  integrity sha512-GB3ZLXiyBmzbdur6dwqlf26+LSqeza2i5rE3sCu0vcbZ1R5+Av/vQyTZvh3zD/s4/8bdsnH942IvGu+sQqacqw==
+  dependencies:
+    base64url "^3.0.1"
+    clone "^2.1.2"
+
 "@ethersproject/abi@^5.0.0", "@ethersproject/abi@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.3.tgz#27280ff9d44b94b5ac83064db81deb8d1b87dab1"
@@ -339,24 +347,25 @@
   dependencies:
     create-hmac "^1.1.7"
 
-"@jolocom/jolo-did-registrar@^1.0.0-rc5":
-  version "1.0.0-rc5"
-  resolved "https://registry.yarnpkg.com/@jolocom/jolo-did-registrar/-/jolo-did-registrar-1.0.0-rc5.tgz#4bd2563493c1a0c47d6d1c3b74c654e10361a089"
-  integrity sha512-1pu342rXfoMgiq4ZQZCJxNniwdt9WIXXDatTOtA6zDsPFuwyDSPaduV9kFS6n4vVmf4lIfEgkRmPANy8x8aUkw==
+"@jolocom/jolo-did-registrar@^1.0.0-rc6":
+  version "1.0.0-rc6"
+  resolved "https://registry.yarnpkg.com/@jolocom/jolo-did-registrar/-/jolo-did-registrar-1.0.0-rc6.tgz#67d961cf09eb4fbf6ab066f06741fc738ee317d0"
+  integrity sha512-C+ZmpyJ/SS/txKoVv2JxN3n7X426iym5n+GoHsbTOrMbU7RwWeAQu9cXVGOGM0isdBIvUqY4qlkySubX/DYs+A==
   dependencies:
+    "@decentralized-identity/did-common-typescript" "^0.1.19"
     "@jolocom/registry-contract" "^1.0.0-rc5"
     detect-node "^2.0.4"
     form-data "^3.0.0"
-    node-fetch "^2.6.0"
+    node-fetch "^2.6.1"
 
-"@jolocom/jolo-did-resolver@^1.0.0-rc5":
-  version "1.0.0-rc5"
-  resolved "https://registry.yarnpkg.com/@jolocom/jolo-did-resolver/-/jolo-did-resolver-1.0.0-rc5.tgz#0411ec2eabb9b1dd2881a5ce7779ff6dfcf2b13f"
-  integrity sha512-Yb4NBL8gaNvDKtpj/SLMGJURvtQ2xLJTYmRC9c7yGZ65ekcAnSPm5T8YbToYYNHa0TWCu6ZbJmXKsF/hDoLZHw==
+"@jolocom/jolo-did-resolver@^1.0.0-rc6":
+  version "1.0.0-rc6"
+  resolved "https://registry.yarnpkg.com/@jolocom/jolo-did-resolver/-/jolo-did-resolver-1.0.0-rc6.tgz#4adc6f8d00687a22e4e10d87d682adf0730f17ea"
+  integrity sha512-7/c3JClqj2W4bUj1Q/wk+u9aJPKlDLFxuKgo1yNYWru8/HUzuhmL4AmKUDKChuy6Cwk9a8IzObbUZd1c/NX5rQ==
   dependencies:
     "@jolocom/registry-contract" "^1.0.0-rc5"
     detect-node "^2.0.4"
-    node-fetch "^2.6.0"
+    node-fetch "^2.6.1"
 
 "@jolocom/local-resolver-registrar@^1.0.0-rc1":
   version "1.0.0-rc1"
@@ -776,6 +785,11 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+clone@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -1244,20 +1258,19 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-jolocom-lib@^5.1.0-rc9:
-  version "5.1.0-rc9"
-  resolved "https://registry.yarnpkg.com/jolocom-lib/-/jolocom-lib-5.1.0-rc9.tgz#2993f910bac0a04aa07f5b2609a46c3aaeb69b86"
-  integrity sha512-elAeOffq1z44SOvqRTOvrVzfao/+moseew/h7a9XWR0UL2jdjNu1NAdLCRfSj2uoVZtgNsuhsZP1sAc/camv9w==
+jolocom-lib@^5.1.0-rc12:
+  version "5.1.0-rc12"
+  resolved "https://registry.yarnpkg.com/jolocom-lib/-/jolocom-lib-5.1.0-rc12.tgz#04e332293adc0fd19d34ac0e5c91eb5eda6d37c9"
+  integrity sha512-mGHygJkjJKFrxHHnqU7Rvu8T4Crwg7fpYMnFKG9E8lOgpPbcXoLMwUdwtXWW+mbCBRp4KxqolgGvDnqDKCOcYQ==
   dependencies:
     "@hawkingnetwork/ed25519-hd-key-rn" "^1.0.1"
-    "@jolocom/jolo-did-registrar" "^1.0.0-rc5"
-    "@jolocom/jolo-did-resolver" "^1.0.0-rc5"
+    "@jolocom/jolo-did-registrar" "^1.0.0-rc6"
+    "@jolocom/jolo-did-resolver" "^1.0.0-rc6"
     "@jolocom/local-resolver-registrar" "^1.0.0-rc1"
     "@jolocom/native-core" "^1.0.0-rc4"
     "@jolocom/protocol-ts" "^0.5.1"
     "@jolocom/vaulted-key-provider" "^0.7.4"
     "@types/sinon" "^9.0.5"
-    base64url "^3.0.1"
     bip39 "^3.0.2"
     class-transformer "^0.3.1"
     create-hash "^1.2.0"
@@ -1267,8 +1280,9 @@ jolocom-lib@^5.1.0-rc9:
     json-logic-js "^1.2.2"
     jsonld "^1.6.1"
     jsontokens "^1.0.0"
-    node-fetch "^2.3.0"
+    node-fetch "^2.6.1"
     reflect-metadata "^0.1.13"
+    rfc4648 "^1.4.0"
     secrets.js-grempe "^1.1.0"
 
 js-sha3@0.5.7:
@@ -1442,10 +1456,10 @@ node-addon-api@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
-node-fetch@^2.3.0, node-fetch@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@^0.9.1:
   version "0.9.1"


### PR DESCRIPTION
NOTE: Not sure if the new entity is necessary, since we use it in place of the old cache for DIDDocs. Didn't want to change the existing API, so settled on a new entity, but the old one doesn't seem to have other usages. I guess refactoring the get/store functions for the cached didDoc will be a better way to go.